### PR TITLE
Allow for fallback values to be passed to design token()

### DIFF
--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -12,7 +12,7 @@
  * @return {string|undefined}
  *   The token value or undefined if it wasn't found.
  */
-module.exports = (token, tokens) => {
+module.exports = (token, tokens, fallback) => {
   // Attempt to get the token value by splitting the string.
   let value
   try {
@@ -21,6 +21,9 @@ module.exports = (token, tokens) => {
     value = null
   }
   if (!value) {
+	if (fallback) {
+		return fallback
+	}
     throw `Could not find the ${token} token`
   }
   return value

--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -21,9 +21,9 @@ module.exports = (token, tokens, fallback) => {
     value = null
   }
   if (!value) {
-	if (fallback) {
-		return fallback
-	}
+    if (fallback) {
+      return fallback
+    }
     throw `Could not find the ${token} token`
   }
   return value

--- a/lib/parseResult.js
+++ b/lib/parseResult.js
@@ -16,9 +16,9 @@ const parseTokenNode = require("./parseTokenNode")
 module.exports = (result, tokens) =>
   parser(result)
     .walk(node => {
-      const token = parseTokenNode(node)
+      const { token, fallback } = parseTokenNode(node)
       if (token) {
-        const value = getToken(token, tokens)
+        const value = getToken(token, tokens, fallback)
         node.type = "word"
         node.value = value
       }

--- a/lib/parseTokenNode.js
+++ b/lib/parseTokenNode.js
@@ -11,7 +11,10 @@ const parser = require("postcss-value-parser")
  */
 module.exports = node => {
   if (node.type !== "function" || node.value !== "token") {
-    return false
+    return {
+		token: false,
+		fallback: false,
+	}
   }
 
   // Use the first arg only.
@@ -30,5 +33,17 @@ module.exports = node => {
     token = token.replace(search, "")
   }
 
-  return token
+  // Loop through to find any fallbacks
+  let fallback = false
+  node.nodes.forEach(node => {
+	if (node.type === "word" && node.value) {
+		fallback = node.value
+		return false			
+	}
+  })
+
+  return {
+	token,
+	fallback,
+  }
 }

--- a/lib/parseTokenNode.js
+++ b/lib/parseTokenNode.js
@@ -12,9 +12,9 @@ const parser = require("postcss-value-parser")
 module.exports = node => {
   if (node.type !== "function" || node.value !== "token") {
     return {
-		token: false,
-		fallback: false,
-	}
+      token: false,
+      fallback: false,
+    }
   }
 
   // Use the first arg only.
@@ -36,14 +36,14 @@ module.exports = node => {
   // Loop through to find any fallbacks
   let fallback = false
   node.nodes.forEach(node => {
-	if (node.type === "word" && node.value) {
-		fallback = node.value
-		return false			
-	}
+    if (node.type === "word" && node.value) {
+      fallback = node.value
+      return false
+    }
   })
 
   return {
-	token,
-	fallback,
+    token,
+    fallback,
   }
 }

--- a/lib/parseTokenNode.js
+++ b/lib/parseTokenNode.js
@@ -33,10 +33,15 @@ module.exports = node => {
     token = token.replace(search, "")
   }
 
+  const rest_of_nodes = node.nodes.slice(1)
+
   // Loop through to find any fallbacks
   let fallback_parts = []
-  node.nodes.forEach(node => {
-    if (node.type === "word" && node.value) {
+  rest_of_nodes.forEach((node, index) => {
+    if (index === 0) {
+      return false
+    }
+    if (["word", "string"].includes(node.type) && node.value) {
       fallback_parts.push(node.value)
     }
   })

--- a/lib/parseTokenNode.js
+++ b/lib/parseTokenNode.js
@@ -34,13 +34,17 @@ module.exports = node => {
   }
 
   // Loop through to find any fallbacks
-  let fallback = false
+  let fallback_parts = []
   node.nodes.forEach(node => {
     if (node.type === "word" && node.value) {
-      fallback = node.value
-      return false
+      fallback_parts.push(node.value)
     }
   })
+
+  let fallback = false
+  if (fallback_parts.length) {
+    fallback = fallback_parts.join(" ")
+  }
 
   return {
     token,


### PR DESCRIPTION
This allows us to set fallback values as part of the `token()` instead of having to create a fallback token.json file.

Old: `background-color: token("footer.background.color");`
New: `background-color: token("footer.background.color" #313133);`